### PR TITLE
New feature:  ?import= allows importing BASE64-encoded Wallet JSON directly

### DIFF
--- a/src/client/pages/Home.page.vue
+++ b/src/client/pages/Home.page.vue
@@ -114,11 +114,13 @@
 
         methods: {
             _blockchainStatus(data) {
+                console.log("blockchain/status - " + data.message);
                 if (data.message === "Single Window") {
                     this.protocolUsedOnMultipleTabs = false;
                 } else if (data.message === "Multiple Windows Detected") {
                     this.protocolUsedOnMultipleTabs = true;
-                } else if (data.message === "Wallet Loaded Successfully") {
+                } else if (data.message === "Wallet Loaded Successfully"
+                           || data.message === "Wallet Creating New Wallet") {
                     // Now that wallet is loaded, check ?import= if we have a new address to add
                     if (typeof this.$route.query.import === "string") {
                         try {

--- a/src/client/pages/Home.page.vue
+++ b/src/client/pages/Home.page.vue
@@ -114,7 +114,7 @@
 
         methods: {
             _blockchainStatus(data) {
-                console.log("blockchain/status - " + data.message);
+                //console.log("blockchain/status - " + data.message);
                 if (data.message === "Single Window") {
                     this.protocolUsedOnMultipleTabs = false;
                 } else if (data.message === "Multiple Windows Detected") {

--- a/src/client/pages/Home.page.vue
+++ b/src/client/pages/Home.page.vue
@@ -100,6 +100,7 @@
 
                 self.loadPoolSettings();
             });
+
         },
 
         destroyed() {
@@ -117,6 +118,20 @@
                     this.protocolUsedOnMultipleTabs = false;
                 } else if (data.message === "Multiple Windows Detected") {
                     this.protocolUsedOnMultipleTabs = true;
+                } else if (data.message === "Wallet Loaded Successfully") {
+                    // Now that wallet is loaded, check ?import= if we have a new address to add
+                    if (typeof this.$route.query.import === "string") {
+                        try {
+                            let wallet = window.atob(this.$route.query.import);
+                            let data = JSON.parse(wallet);
+                            let answer = WebDollar.Blockchain.Wallet.importAddressFromJSON(data);
+                            if (answer.result === true) {
+                                console.log("Query-string Address Import Successful!");
+                            }
+                        } catch (err) {
+                            console.log("Error decoding wallet-address import querystring: " + err);
+                        }
+                    }
                 }
             },
 


### PR DESCRIPTION
This is a new feature to enable the home page to check ?import= query string; contents should be a BASE64-encoded wallet JSON (e.g. base64 encoding a .webd downloaded wallet).

This allows us to stuff wallets into a https://webdollar.io/?import=<wallet base64> URL, QR-code it, and have WebDollar Gift Cards!

Gift someone a webdollar account with preloaded balance!