### PR TITLE
Show WEBD price / statistics from Coin Gecko under the distribution metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6500,9 +6500,9 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lru-cache": "^5.1.1",
     "md5": "^2.2.1",
     "mini-css-extract-plugin": "^0.5.0",
+    "moment": "^2.29.1",
     "node-sass": "^4.11.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "pem": "^1.14.2",

--- a/public/assets/styles/mobile.css
+++ b/public/assets/styles/mobile.css
@@ -716,6 +716,14 @@
         padding-bottom: 20px;
     }
 
+    .distributionContainer .footer{
+        grid-template-columns: 1fr 1fr;
+        padding-bottom: 20px;
+        padding-top: 20px;
+        width: 100%;
+        transform:translateX(0%);
+    }
+
     .bountyCampaigns span {
         width: 12%;
     }
@@ -813,6 +821,7 @@
     .distributionContainer .stats{
         grid-template-columns: 1fr;
     }
+
     #mediaContainer{
         grid-template-columns: 1fr;
         padding: 0 10px;

--- a/public/assets/styles/stylesheet.css
+++ b/public/assets/styles/stylesheet.css
@@ -1244,6 +1244,42 @@ background-color:#ff2200}
   width: 100%;
 }
 
+.distributionContainer .footer{
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  padding-bottom: 10px;
+  padding-top: 40px;
+  width: 120%;
+  transform:translateX(-10%);
+}
+
+.distributionContainer .footer .bottom-gutter{
+  grid-column-start: 1;
+  grid-column-end: 5;
+}
+
+.distributionContainer .footer .value{
+  color: #fff;
+  text-align: center;
+  font-size: 16px;
+  font-weight: bolder;
+  padding-bottom: 10px;
+}
+
+.distributionContainer .footer .description{
+  color: #ccc;
+  text-align: center;
+  font-size: 12px;
+  width: 100%;
+}
+
+.distributionContainer .footer .description-smaller{
+  color: #ccc;
+  text-align: center;
+  font-size: 8px;
+  width: 100%;
+}
+
 #newCryptoSection .featuresContainer{
   display: grid;
   grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
Under the distribution metrics, show CoinGecko data about WEBD.

Web view:

![web view with all statistics](https://user-images.githubusercontent.com/8010983/117756704-e7369400-b1db-11eb-9b36-7c052f056937.png)

Mobile view:

![mobile view with price and 24hr change only](https://user-images.githubusercontent.com/8010983/117756758-06352600-b1dc-11eb-8680-ff231f1a2c5b.png)

I hid some of the larger statistics on mobile since it's harder to display market cap & 24hr volume since these are big numbers.

---

This currently supports all conversions available on CoinGecko.

![dropdown of currencies](https://user-images.githubusercontent.com/8010983/117756901-41cff000-b1dc-11eb-8b6a-32aee1b915da.png)

This will be nice to allow users to see some high level metrics on WEBD 😄 

