### PR TITLE
Fix dark mode as default

### DIFF
--- a/src/store/modules/settings/settings-mutations.js
+++ b/src/store/modules/settings/settings-mutations.js
@@ -14,7 +14,11 @@ export default {
     },
 
     readLocalStorage(state){
-        state.dark = ( localStorage.getItem('dark') || 'false' ) === 'true'
+        if (localStorage.getItem('dark') === null) {
+          state.dark = true
+        } else {
+          state.dark = localStorage.getItem('dark') === 'true'
+        }
         if (state.dark) {
             document.getElementsByTagName("html")[0].classList.remove('light');
         } else {


### PR DESCRIPTION
Following PR #85 with new light theme, this PR fixes the default theme: dark mode is active by default.